### PR TITLE
change Guard::Guard to Guard::Plugin

### DIFF
--- a/guard-clockwork.gemspec
+++ b/guard-clockwork.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = %w(lib)
 
-  spec.add_dependency 'guard', '>= 1.1'
+  spec.add_dependency 'guard', '>= 2.0'
   spec.add_dependency 'clockwork'
 
   spec.add_development_dependency 'bundler', '~> 1.3'

--- a/lib/guard/clockwork.rb
+++ b/lib/guard/clockwork.rb
@@ -1,9 +1,9 @@
 require 'guard'
-require 'guard/guard'
+require 'guard/plugin'
 require 'guard/clockwork/version'
 
 module Guard
-  class Clockwork < Guard
+  class Clockwork < Plugin
     DEFAULT_CLOCKFILE = 'config/clock.rb'
 
     def initialize(watchers = [], options = {})


### PR DESCRIPTION
@deepblue 

This makes this gem compatible with guard 2.x, as `Guard::Guard` has been deprecated.
